### PR TITLE
V0.0.13

### DIFF
--- a/BloodyStory/BleedParticles.cs
+++ b/BloodyStory/BleedParticles.cs
@@ -1,0 +1,59 @@
+﻿using ProtoBuf;
+using Vintagestory.API.Common;
+using Vintagestory.API.MathTools;
+
+namespace BloodyStory
+{
+    [ProtoContract(ImplicitFields=ImplicitFields.AllFields)]
+    internal class BleedParticles : AdvancedParticleProperties
+    {
+        public BleedParticles()
+        {
+            HsvaColor = new NatFloat[]
+                {
+                    NatFloat.Zero,
+                    NatFloat.createUniform(255f,0f),
+                    NatFloat.createUniform(255f,0f),
+                    NatFloat.createUniform(255f,0f)
+                };
+            LifeLength = NatFloat.One;
+            GravityEffect = NatFloat.One;
+            Size = NatFloat.createUniform(0.35f, 0.15f);
+            DieInLiquid = true;
+            DeathParticles = new AdvancedParticleProperties[]{
+                new()
+                {
+                    Quantity = NatFloat.One,
+                    ParentVelocityWeight = 1f,
+                    Velocity = new NatFloat[]
+                    {
+                        NatFloat.Zero,
+                        NatFloat.Zero,
+                        NatFloat.Zero
+                    },
+                    HsvaColor = new NatFloat[]
+                    {
+                        NatFloat.Zero,
+                        NatFloat.createUniform(255f,0f),
+                        NatFloat.createUniform(255f,0f),
+                        NatFloat.createUniform(255f,0f)
+                    },
+                    PosOffset = new NatFloat[]
+                    {
+                        NatFloat.Zero,
+                        NatFloat.Zero,
+                        NatFloat.Zero
+                    },
+                    ParticleModel = EnumParticleModel.Quad,
+                    DieInAir = true,
+                    SwimOnLiquid = false,
+                    GravityEffect = NatFloat.createUniform(0.05f, 0.05f),
+                    Size = NatFloat.createUniform(0.2f, 0.15f),
+                    SizeEvolve = EvolvingNatFloat.create(EnumTransformFunction.LINEARINCREASE, 1f),
+                    OpacityEvolve = EvolvingNatFloat.create(EnumTransformFunction.LINEARNULLIFY, -255f)
+                }
+            };
+            ParticleModel = EnumParticleModel.Cube;
+        }
+    }
+}

--- a/BloodyStory/BloodyStoryModSystem.cs
+++ b/BloodyStory/BloodyStoryModSystem.cs
@@ -94,12 +94,12 @@ namespace BloodyStory
             if (bleedEB.pauseBleedProcess)
             {
                 bleedEB.pauseBleedProcess = false;
-                player.SendMessage(GlobalConstants.GeneralChatGroup, "Bleeding resumed", EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleed-resumed"), EnumChatType.Notification);
             }
             else
             {
                 bleedEB.pauseBleedProcess = true;
-                player.SendMessage(GlobalConstants.GeneralChatGroup, "Bleeding paused", EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleed-paused"), EnumChatType.Notification);
             }
 
             return TextCommandResult.Success();
@@ -114,12 +114,12 @@ namespace BloodyStory
             if (bleedEB.pauseBleedParticles)
             {
                 bleedEB.pauseBleedParticles = false;
-                player.SendMessage(GlobalConstants.GeneralChatGroup, "Bleeding resumed", EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleed-resumed"), EnumChatType.Notification);
             }
             else
             {
                 bleedEB.pauseBleedParticles = true;
-                player.SendMessage(GlobalConstants.GeneralChatGroup, "Bleeding paused", EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleed-paused"), EnumChatType.Notification);
             }
 
             return TextCommandResult.Success();
@@ -141,14 +141,14 @@ namespace BloodyStory
             {
                 bleedEB.OnBleedout -= dele;
                 bleedoutDelegateDict.Remove(bleedEB);
-                player.SendMessage(GlobalConstants.GeneralChatGroup, "Bleedout enabled", EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleedout-enabled"), EnumChatType.Notification);
             }
             else
             {
                 dele = (out bool shouldDie, DamageSource _) => { shouldDie = false; };
                 bleedEB.OnBleedout += dele;
                 bleedoutDelegateDict.Add(bleedEB, dele);
-                player.SendMessage(GlobalConstants.GeneralChatGroup, "Bleedout disabled", EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleedout-disabled"), EnumChatType.Notification);
             }
 
             return TextCommandResult.Success();
@@ -178,9 +178,7 @@ namespace BloodyStory
 
             player.Entity.GetBehavior<EntityBehaviorBleed>().bleedLevel += amount;
 
-            player.SendMessage(GlobalConstants.GeneralChatGroup, "Added " + amount + " bleed", EnumChatType.Notification);
-
-            return TextCommandResult.Success();
+            return TextCommandResult.Success(Lang.Get("command-bleed-added", new object[] { amount }));
         }
 
         public override void StartClientSide(ICoreClientAPI api)
@@ -192,15 +190,9 @@ namespace BloodyStory
             IServerPlayer player = args.Caller.Player as IServerPlayer;
             EntityBehaviorBleed bleedEB = player.Entity.GetBehavior<EntityBehaviorBleed>();
 
-            player.SendMessage(GlobalConstants.GeneralChatGroup, "Bleed level: " + bleedEB.bleedLevel, EnumChatType.Notification);
+            string message = Lang.Get("command-bleed-stats", new object[] { bleedEB.bleedLevel, bleedEB.GetBleedRate(true), bleedEB.GetRegenRate(true), bleedEB.regenBoost });
 
-            player.SendMessage(GlobalConstants.GeneralChatGroup, "Bleed rate: " + bleedEB.GetBleedRate(true) + " HP/s", EnumChatType.Notification);
-
-            player.SendMessage(GlobalConstants.GeneralChatGroup, "Current regen rate: " + bleedEB.GetRegenRate(true) + " HP/s", EnumChatType.Notification);
-
-            player.SendMessage(GlobalConstants.GeneralChatGroup, "Remaining regen boost: " + bleedEB.regenBoost + " HP", EnumChatType.Notification);
-
-            return TextCommandResult.Success();
+            return TextCommandResult.Success(message);
         }
     }
 }

--- a/BloodyStory/BloodyStoryModSystem.cs
+++ b/BloodyStory/BloodyStoryModSystem.cs
@@ -166,7 +166,7 @@ namespace BloodyStory
 
         private TextCommandResult ReloadConfigCommand(TextCommandCallingArgs args)
         {
-            Config.Reload();
+            api.Event.EnqueueMainThreadTask(Config.Reload, "bsconfigreload");
 
             return TextCommandResult.Success();
         }

--- a/BloodyStory/BloodyStoryModSystem.cs
+++ b/BloodyStory/BloodyStoryModSystem.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Vintagestory.API.Client;
 using Vintagestory.API.Common;
+using Vintagestory.API.Common.Entities;
 using Vintagestory.API.Config;
 using Vintagestory.API.Server;
 
@@ -9,6 +10,7 @@ namespace BloodyStory
 {
     public class BloodyStoryModSystem : ModSystem // rewrite all of this as an entitybehaviour at some point
     {
+        public const string bloodParticleNetChannel = "bloodystory:particles";
         public BloodyStoryModConfig modConfig => Config.modConfig;
 
         public static ConfigManager Config
@@ -25,7 +27,10 @@ namespace BloodyStory
             base.Start(api);
             this.api = api;
 
-            Config = new(api, "bloodystory.json", "bloodystory");
+            Config = new(api, "bloodystory.json", "bloodystory:config");
+            
+            api.Network.RegisterUdpChannel(bloodParticleNetChannel)
+                .RegisterMessageType<BleedParticles>();
 
             api.RegisterEntityBehaviorClass("bleed", typeof(EntityBehaviorBleed));
 

--- a/BloodyStory/BloodyStoryModSystem.cs
+++ b/BloodyStory/BloodyStoryModSystem.cs
@@ -59,11 +59,6 @@ namespace BloodyStory
                 .WithArgs(new ICommandArgumentParser[] { sapi.ChatCommands.Parsers.OptionalDouble("bleedAmount", 1) })
                 .HandleWith(MakeMeBleedCommand);
 
-            sapi.ChatCommands.Create("bsconfigreload")
-                .WithDescription("Reloads Bloody Story config file")
-                .RequiresPrivilege(Privilege.root)
-                .HandleWith(ReloadConfigCommand);
-
             sapi.ChatCommands.Create("preventbleedout")
                 .WithDescription("Toggles player bleedout (player will not die from bleed)")
                 .RequiresPlayer()
@@ -94,12 +89,12 @@ namespace BloodyStory
             if (bleedEB.pauseBleedProcess)
             {
                 bleedEB.pauseBleedProcess = false;
-                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleed-resumed"), EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("bloodystory:command-bleed-resumed"), EnumChatType.Notification);
             }
             else
             {
                 bleedEB.pauseBleedProcess = true;
-                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleed-paused"), EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("bloodystory:command-bleed-paused"), EnumChatType.Notification);
             }
 
             return TextCommandResult.Success();
@@ -114,12 +109,12 @@ namespace BloodyStory
             if (bleedEB.pauseBleedParticles)
             {
                 bleedEB.pauseBleedParticles = false;
-                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleed-resumed"), EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("bloodystory:command-bleed-resumed"), EnumChatType.Notification);
             }
             else
             {
                 bleedEB.pauseBleedParticles = true;
-                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleed-paused"), EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("bloodystory:command-bleed-paused"), EnumChatType.Notification);
             }
 
             return TextCommandResult.Success();
@@ -141,14 +136,14 @@ namespace BloodyStory
             {
                 bleedEB.OnBleedout -= dele;
                 bleedoutDelegateDict.Remove(bleedEB);
-                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleedout-enabled"), EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("bloodystory:command-bleedout-enabled"), EnumChatType.Notification);
             }
             else
             {
                 dele = (out bool shouldDie, DamageSource _) => { shouldDie = false; };
                 bleedEB.OnBleedout += dele;
                 bleedoutDelegateDict.Add(bleedEB, dele);
-                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("command-bleedout-disabled"), EnumChatType.Notification);
+                player.SendMessage(GlobalConstants.GeneralChatGroup, Lang.Get("bloodystory:command-bleedout-disabled"), EnumChatType.Notification);
             }
 
             return TextCommandResult.Success();
@@ -164,12 +159,6 @@ namespace BloodyStory
             bleedEB.pauseBleedProcess = false;
         }
 
-        private TextCommandResult ReloadConfigCommand(TextCommandCallingArgs args)
-        {
-            api.Event.EnqueueMainThreadTask(Config.Reload, "bsconfigreload");
-
-            return TextCommandResult.Success();
-        }
         private TextCommandResult MakeMeBleedCommand(TextCommandCallingArgs args)
         {
             IServerPlayer player = args.Caller.Player as IServerPlayer;
@@ -178,7 +167,7 @@ namespace BloodyStory
 
             player.Entity.GetBehavior<EntityBehaviorBleed>().bleedLevel += amount;
 
-            return TextCommandResult.Success(Lang.Get("command-bleed-added", new object[] { amount }));
+            return TextCommandResult.Success(Lang.Get("bloodystory:command-bleed-added", new object[] { amount }));
         }
 
         public override void StartClientSide(ICoreClientAPI api)
@@ -190,7 +179,7 @@ namespace BloodyStory
             IServerPlayer player = args.Caller.Player as IServerPlayer;
             EntityBehaviorBleed bleedEB = player.Entity.GetBehavior<EntityBehaviorBleed>();
 
-            string message = Lang.Get("command-bleed-stats", new object[] { bleedEB.bleedLevel, bleedEB.GetBleedRate(true), bleedEB.GetRegenRate(true), bleedEB.regenBoost });
+            string message = Lang.Get("bloodystory:command-bleed-stats", new object[] { bleedEB.bleedLevel, bleedEB.GetBleedRate(true), bleedEB.GetRegenRate(true), bleedEB.regenBoost });
 
             return TextCommandResult.Success(message);
         }

--- a/BloodyStory/Config/BloodyStoryModConfig.cs
+++ b/BloodyStory/Config/BloodyStoryModConfig.cs
@@ -16,6 +16,9 @@ namespace BloodyStory.Config
         public int regenSitDelay = 5000; // delay before the sit boost is applied, in ms
         public double regenSitMultiplier = 3f; // multiplier for regen when sitting
 
+        public float bleedDamageMultiplier = 1f; // multiplier for damage taken as bleed
+        public float directDamageMultiplier = 0f; // multiplier for damage allowed through after bleed is applied
+
         public double bleedHealRate = 0.15f; // natural bleeding reduction
         public double bleedQuotient = 12f; // quotient for hp loss to bleed
         public double sneakMultiplier = 8f; // multiplier for bleed quotient applied when sneaking

--- a/BloodyStory/Config/BloodyStoryModConfig.cs
+++ b/BloodyStory/Config/BloodyStoryModConfig.cs
@@ -33,7 +33,7 @@ namespace BloodyStory.Config
         public float maxSatietyMultiplier = 1.2f; // multiplier for regen rate at maximum hunger saturation
         public float minSatietyMultiplier = 0f; // multiplier for regen rate at minimum hunger saturation
 
-        public float satietyConsumption = 1f; // hunger saturation consumed per point of hp restored (sans bonus)
+        public float satietyConsumption = 50f; // hunger saturation consumed per point of hp restored
 
         public float timeDilation = 1.0f; // to adjust simulated second speed, for if game speed is changed
     }

--- a/BloodyStory/Config/ConfigManager.cs
+++ b/BloodyStory/Config/ConfigManager.cs
@@ -77,7 +77,7 @@ namespace BloodyStory.Config
                     _modConfig = new BloodyStoryModConfig();
                     RequestConfig();
                     requestedConfig = true;
-                    capi.Event.RegisterCallback((float d) => { requestedConfig = false; }, 5000);
+                    capi.Event.EnqueueMainThreadTask(() => { capi.Event.RegisterCallback((float d) => { requestedConfig = false; }, 5000); }, "registerconfigcallback");
                     break;
                 case (EnumAppSide.Server):
                     api.Logger.Event("[{0}] trying to load config", new object[] {NetChannel});

--- a/BloodyStory/Config/ConfigManager.cs
+++ b/BloodyStory/Config/ConfigManager.cs
@@ -77,7 +77,7 @@ namespace BloodyStory.Config
                     _modConfig = new BloodyStoryModConfig();
                     RequestConfig();
                     requestedConfig = true;
-                    api.Event.RegisterCallback((float d) => { requestedConfig = false; }, 5000);
+                    capi.Event.RegisterCallback((float d) => { requestedConfig = false; }, 5000);
                     break;
                 case (EnumAppSide.Server):
                     api.Logger.Event("[{0}] trying to load config", new object[] {NetChannel});
@@ -87,13 +87,14 @@ namespace BloodyStory.Config
                         api.Logger.Event("[{0}] generating new config", new object[] { NetChannel });
                         _modConfig = new BloodyStoryModConfig();
                         api.StoreModConfig(_modConfig, ConfigFilename);
-                    }
+                    } else api.Logger.Event("[{0}] config loaded", new object[] { NetChannel });
                     BroadcastConfig();
                     break;
             }
         }
         public void RequestConfig()
         {
+            api.Logger.Event("[{0}] requesting config from server", new object[] { NetChannel });
             capi.Network.GetChannel(NetChannel).SendPacket<NetMessage_Request>(new());
         }
         private void ReceiveConfig(BloodyStoryModConfig packet)
@@ -109,6 +110,7 @@ namespace BloodyStory.Config
         }
         public void BroadcastConfig()
         {
+            api.Logger.Event("[{0}] broadcasting config to all players", new object[] { NetChannel });
             sapi.Network.GetChannel(NetChannel).BroadcastPacket(modConfig);
         }
 

--- a/BloodyStory/EntityBehaviorBleed.cs
+++ b/BloodyStory/EntityBehaviorBleed.cs
@@ -170,7 +170,7 @@ namespace BloodyStory
                     hungerConsumption += (float)Math.Min(dt * modConfig.regenBoostRate, regenBoost) * modConfig.satietyConsumption;
                 }
             }
-            pHunger.ConsumeSaturation(hungerConsumption);
+            if (hungerConsumption > 0) pHunger.ConsumeSaturation(hungerConsumption);
 
             if (regenBoost != 0)
             {

--- a/BloodyStory/EntityBehaviorBleed.cs
+++ b/BloodyStory/EntityBehaviorBleed.cs
@@ -276,30 +276,32 @@ namespace BloodyStory
                     bleedRate -= damage;
                     if (bleedRate < 0) bleedRate = 0;
                     bleedLevel = bleedRate;
-                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get( "damagelog-bleed-healed" , new object[] { Math.Round(damage / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
+                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("bloodystory:damagelog-bleed-healed" , new object[] { Math.Round(damage / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
                     ReceiveDamageReplacer(byPlayer, dmgSource, damage);
                     damage = 0;
                     break;
                 case EnumDamageType.BluntAttack:
                 case EnumDamageType.SlashingAttack:
                 case EnumDamageType.PiercingAttack:
-                    bleedLevel += damage;
+                    float bleedDamage = damage;
+                    bleedDamage *= modConfig.bleedDamageMultiplier;
+                    bleedLevel += bleedDamage;
                     lastHit = dmgSource;
-                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("damagelog-bleed-gained", new object[] { Math.Round(damage / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
+                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("bloodystory:damagelog-bleed-gained", new object[] { Math.Round(damage * modConfig.bleedDamageMultiplier / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
                     ReceiveDamageReplacer(byPlayer, dmgSource, damage);
-                    damage = 0;
+                    damage *= modConfig.directDamageMultiplier;
                     break;
                 case EnumDamageType.Poison:
                     bleedLevel += damage;
                     lastHit = dmgSource;
-                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("damagelog-bleed-gained", new object[] { Math.Round(damage / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
+                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("bloodystory:damagelog-bleed-gained", new object[] { Math.Round(damage / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
                     ReceiveDamageReplacer(byPlayer, dmgSource, damage);
                     damage = 0;
                     break;
                 case EnumDamageType.Gravity: break;
                 case EnumDamageType.Fire:
                     bleedLevel -= damage * modConfig.bleedCautMultiplier;
-                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("damagelog-bleed-cauterised", new object[] { Math.Round(damage * modConfig.bleedCautMultiplier / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
+                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("bloodystory:damagelog-bleed-cauterised", new object[] { Math.Round(damage * modConfig.bleedCautMultiplier / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
                     break; // :]
                 case EnumDamageType.Suffocation: break;
                 case EnumDamageType.Hunger: break;
@@ -363,7 +365,7 @@ namespace BloodyStory
         {
             double regenBoostAdd = saturation / modConfig.regenBoostQuotient;
             regenBoost += regenBoostAdd;
-            ((IServerPlayer)((EntityPlayer)entity).Player).SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("damagelog-regenboost-gained", new object[] { Math.Round(regenBoostAdd, 1) }), EnumChatType.Notification);
+            ((IServerPlayer)((EntityPlayer)entity).Player).SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("bloodystory:damagelog-regenboost-gained", new object[] { Math.Round(regenBoostAdd, 1) }), EnumChatType.Notification);
         }
 
         void SpawnBloodParticles()

--- a/BloodyStory/EntityBehaviorBleed.cs
+++ b/BloodyStory/EntityBehaviorBleed.cs
@@ -202,13 +202,13 @@ namespace BloodyStory
         {
             if (OnBleedout != null)
             {
+                bool shouldDie = true;
                 foreach (OnBleedoutDelegate d in OnBleedout.GetInvocationList())
                 {
-                    bool shouldDie = true;
                     d(out shouldDie, lastHit);
+                }
                     if (!shouldDie) return;
                 }
-            }
 
             entity.Die(EnumDespawnReason.Death, lastHit);
         }

--- a/BloodyStory/EntityBehaviorBleed.cs
+++ b/BloodyStory/EntityBehaviorBleed.cs
@@ -192,9 +192,13 @@ namespace BloodyStory
                 }
             }
             hungerTickTimer += dtr;
-            if (hungerTickTimer > 1f) 
-                if (hungerConsumption > 0) 
+            if (hungerTickTimer > 1f)
+                if (hungerConsumption > 0)
+                {
                     pHunger.ConsumeSaturation(hungerConsumption);
+                    hungerTickTimer = 0f;
+                    hungerConsumption = 0f;
+                }
 
             if (regenBoost != 0)
             {

--- a/BloodyStory/EntityBehaviorBleed.cs
+++ b/BloodyStory/EntityBehaviorBleed.cs
@@ -207,8 +207,8 @@ namespace BloodyStory
                 {
                     d(out shouldDie, lastHit);
                 }
-                    if (!shouldDie) return;
-                }
+                if (!shouldDie) return;
+            }
 
             entity.Die(EnumDespawnReason.Death, lastHit);
         }
@@ -276,7 +276,7 @@ namespace BloodyStory
                     bleedRate -= damage;
                     if (bleedRate < 0) bleedRate = 0;
                     bleedLevel = bleedRate;
-                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, "Healed ~" + Math.Round(damage / modConfig.bleedQuotient, 3) + " HP/s bleed", EnumChatType.Notification); // TODO: localisation
+                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get( "damagelog-bleed-healed" , new object[] { Math.Round(damage / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
                     ReceiveDamageReplacer(byPlayer, dmgSource, damage);
                     damage = 0;
                     break;
@@ -285,20 +285,21 @@ namespace BloodyStory
                 case EnumDamageType.PiercingAttack:
                     bleedLevel += damage;
                     lastHit = dmgSource;
-                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, "Received ~" + Math.Round(damage / modConfig.bleedQuotient, 3) + " HP/s bleed", EnumChatType.Notification); // TODO: localisation
+                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("damagelog-bleed-gained", new object[] { Math.Round(damage / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
                     ReceiveDamageReplacer(byPlayer, dmgSource, damage);
                     damage = 0;
                     break;
                 case EnumDamageType.Poison:
                     bleedLevel += damage;
                     lastHit = dmgSource;
+                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("damagelog-bleed-gained", new object[] { Math.Round(damage / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
                     ReceiveDamageReplacer(byPlayer, dmgSource, damage);
                     damage = 0;
                     break;
                 case EnumDamageType.Gravity: break;
                 case EnumDamageType.Fire:
                     bleedLevel -= damage * modConfig.bleedCautMultiplier;
-                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, "Cauterised ~" + Math.Round(damage * modConfig.bleedCautMultiplier / modConfig.bleedQuotient, 3) + " HP/s bleed", EnumChatType.Notification); // TODO: localisation
+                    byPlayer.SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("damagelog-bleed-cauterised", new object[] { Math.Round(damage * modConfig.bleedCautMultiplier / modConfig.bleedQuotient, 3) }), EnumChatType.Notification);
                     break; // :]
                 case EnumDamageType.Suffocation: break;
                 case EnumDamageType.Hunger: break;
@@ -362,7 +363,7 @@ namespace BloodyStory
         {
             double regenBoostAdd = saturation / modConfig.regenBoostQuotient;
             regenBoost += regenBoostAdd;
-            ((IServerPlayer)((EntityPlayer)entity).Player).SendMessage(GlobalConstants.DamageLogChatGroup, "Received ~" + Math.Round(regenBoostAdd, 1) + " HP of regen boost from food", EnumChatType.Notification); //TODO: localisation
+            ((IServerPlayer)((EntityPlayer)entity).Player).SendMessage(GlobalConstants.DamageLogChatGroup, Lang.Get("damagelog-regenboost-gained", new object[] { Math.Round(regenBoostAdd, 1) }), EnumChatType.Notification);
         }
 
         void SpawnBloodParticles()

--- a/BloodyStory/EntityBehaviorBleed.cs
+++ b/BloodyStory/EntityBehaviorBleed.cs
@@ -108,7 +108,7 @@ namespace BloodyStory
 
         private void ServerTick(float dt)
         {
-            if (entity == null || !entity.Alive || pauseBleedProcess || entity.WatchedAttributes.GetBool("unconscious")) return;
+            if (entity == null || !entity.Alive || pauseBleedProcess) return;
 
             if (((EntityPlayer)entity).Player is not IServerPlayer serverPlayer || serverPlayer.ConnectionState != EnumClientState.Playing) return;
 
@@ -246,8 +246,6 @@ namespace BloodyStory
             }
 
             if (dmgSource.Source == EnumDamageSource.Void) return damage;
-
-            if (playerAttributes.GetBool("unconscious")) return damage;
 
             switch (dmgSource.Type) // possible alternate implementation: dictionary, with dmg type as keys and functions as values?
             {

--- a/BloodyStory/changes.txt
+++ b/BloodyStory/changes.txt
@@ -1,6 +1,9 @@
  - removed now-superfluous "unconscious" check :]
+ - implemented localisation
+ - maybe networked particles? need someone to actually test with other players
+ - two new config options to adjust amount of bleed added and to allow some amount of direct damage through
+ - removed "bsconfigreload" command, since it seems not to work correctly anyway; you'll just have to reload the config the old fashioned way
 
 
 TODO: 
 - handbook entry
-- localisation

--- a/BloodyStory/changes.txt
+++ b/BloodyStory/changes.txt
@@ -1,4 +1,5 @@
-- clients should no longer spam server with config requests (and be spammed with config updates in return)
+ - removed now-superfluous "unconscious" check :]
+
 
 TODO: 
 - handbook entry

--- a/BloodyStory/changes.txt
+++ b/BloodyStory/changes.txt
@@ -3,7 +3,7 @@
  - maybe networked particles? need someone to actually test with other players
  - two new config options to adjust amount of bleed added and to allow some amount of direct damage through
  - removed "bsconfigreload" command, since it seems not to work correctly anyway; you'll just have to reload the config the old fashioned way
-
+ - fix for hunger issues
 
 TODO: 
 - handbook entry

--- a/resources/assets/bloodystory/lang/en.json
+++ b/resources/assets/bloodystory/lang/en.json
@@ -1,3 +1,15 @@
 {
-    "item-improvised-patch": "Improvised Patch"
+  "item-improvised-patch": "Improvised Patch",
+
+  "damagelog-bleed-healed": "Healed ~{0} HP/s bleed",
+  "damagelog-bleed-gained": "Received ~{0} HP/s bleed",
+  "damagelog-bleed-cauterised": "Cauterised ~{0} HP/s bleed",
+  "damagelog-regenboost-gained": "Gained {0} HP of regen boost from food",
+
+  "command-bleed-added": "Added {0} points of bleed",
+  "command-bleed-stats": "Bleed Level: {0}\nBleed Rate: {1} HP/s \nRegen Rate: {2} HP/s \nRemaining Regen Boost: {3} HP",
+  "command-bleedout-enabled": "Bleedout enabled",
+  "command-bleedout-disabled": "Bleedout disabled",
+  "command-bleed-paused": "Bleeding paused",
+  "command-bleed-resumed": "Bleeding resumed"
 }

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
     "Professor Cupcake"
   ],
   "description": "Changes all combat damage to bleeding",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "dependencies": {
     "game": "1.20.0-rc.8"
   },


### PR DESCRIPTION
- removed now-superfluous "unconscious" check :]
- implemented localisation
- maybe networked particles? need someone to actually test with other players
- two new config options to adjust amount of bleed added and to allow some amount of direct damage through
- removed "bsconfigreload" command, since it seems not to work correctly anyway; you'll just have to reload the config the old fashioned way
- fix for hunger issues
- also increased default hunger consumption to 50 satiety/HP