### PR TITLE
V0.0.15

### DIFF
--- a/BloodyStory/BloodyStoryModSystem.cs
+++ b/BloodyStory/BloodyStoryModSystem.cs
@@ -194,27 +194,29 @@ namespace BloodyStory
             target ??= capi.World.Player.Entity;
             EntityBehaviorBleed bleedEB = target.GetBehavior<EntityBehaviorBleed>();
 
-            string message = target.GetName() + "'s bleeding:";
+            string message;
 
             if (modConfig.detailedBleedCheck)
             {
-                message += "-\n" + Lang.Get("bloodystory:command-bleed-stats", new object[] { bleedEB.bleedLevel, bleedEB.GetBleedRate(true), bleedEB.GetRegenRate(true), bleedEB.regenBoost });
+                message = $"{target.GetName()}'s bleeding:-\n" + Lang.Get("bloodystory:command-bleed-stats", new object[] { bleedEB.bleedLevel, bleedEB.GetBleedRate(true), bleedEB.GetRegenRate(true), bleedEB.regenBoost });
             } else
             {
-                string bleedRating; // TODO: replace this hardcoded placeholder with a proper solution
-                if (bleedEB.bleedLevel <= 0)
+                string bleedRating; // TODO: replace this hardcoded placeholder with a proper solution, also localisation
+
+                double bleedLevel = bleedEB.bleedLevel;
+                if (bleedLevel <= 0)
                 {
                     bleedRating = "None";
-                } else if (bleedEB.bleedLevel <= modConfig.bleedRating_Trivial)
+                } else if (bleedLevel <= modConfig.bleedRating_Trivial)
                 {
                     bleedRating = "Trivial";
-                } else if (bleedEB.bleedLevel <= modConfig.bleedRating_Minor)
+                } else if (bleedLevel <= modConfig.bleedRating_Minor)
                 {
                     bleedRating = "Minor";
-                } else if (bleedEB.bleedLevel <= modConfig.bleedRating_Moderate)
+                } else if (bleedLevel <= modConfig.bleedRating_Moderate)
                 {
                     bleedRating = "Moderate";
-                } else if (bleedEB.bleedLevel <= modConfig.bleedRating_Severe)
+                } else if (bleedLevel <= modConfig.bleedRating_Severe)
                 {
                     bleedRating = "Severe";
                 } else
@@ -222,7 +224,7 @@ namespace BloodyStory
                     bleedRating = "Extreme";
                 }
 
-                message += " " + bleedRating;
+                message = $"{target.GetName()}'s bleeding: {bleedRating}";
             }
 
             capi.ShowChatMessage(message);

--- a/BloodyStory/BloodyStoryModSystem.cs
+++ b/BloodyStory/BloodyStoryModSystem.cs
@@ -52,7 +52,8 @@ namespace BloodyStory
             sapi.ChatCommands.Create("bleed")
                 .WithDescription("Outputs precise bleed and regen levels")
                 .RequiresPlayer()
-                .RequiresPrivilege(Privilege.chat)
+                .RequiresPrivilege(Privilege.root)
+                .WithArgs(new ICommandArgumentParser[] { sapi.ChatCommands.Parsers.OnlinePlayer("player") })
                 .HandleWith(BleedCommand);
 
             sapi.ChatCommands.Create("makeMeBleed")
@@ -197,7 +198,7 @@ namespace BloodyStory
 
             if (modConfig.detailedBleedCheck)
             {
-                message += "\n" + Lang.Get("bloodystory:command-bleed-stats", new object[] { bleedEB.bleedLevel, bleedEB.GetBleedRate(true), bleedEB.GetRegenRate(true), bleedEB.regenBoost });
+                message += "-\n" + Lang.Get("bloodystory:command-bleed-stats", new object[] { bleedEB.bleedLevel, bleedEB.GetBleedRate(true), bleedEB.GetRegenRate(true), bleedEB.regenBoost });
             } else
             {
                 string bleedRating; // TODO: replace this hardcoded placeholder with a proper solution
@@ -231,10 +232,11 @@ namespace BloodyStory
 
         private TextCommandResult BleedCommand(TextCommandCallingArgs args)
         {
-            IServerPlayer player = args.Caller.Player as IServerPlayer;
+            IServerPlayer player = args[0] as IServerPlayer;
             EntityBehaviorBleed bleedEB = player.Entity.GetBehavior<EntityBehaviorBleed>();
 
-            string message = Lang.Get("bloodystory:command-bleed-stats", new object[] { bleedEB.bleedLevel, bleedEB.GetBleedRate(true), bleedEB.GetRegenRate(true), bleedEB.regenBoost });
+            string message = player.PlayerName + "'s bleeding:-\n"
+                + Lang.Get("bloodystory:command-bleed-stats", new object[] { bleedEB.bleedLevel, bleedEB.GetBleedRate(true), bleedEB.GetRegenRate(true), bleedEB.regenBoost });
 
             return TextCommandResult.Success(message);
         }

--- a/BloodyStory/Config/BloodyStoryModConfig.cs
+++ b/BloodyStory/Config/BloodyStoryModConfig.cs
@@ -26,7 +26,7 @@ namespace BloodyStory.Config
         public double bleedCautMultiplier = 1f; // multiplier for how much bleed is reduced by fire damage
 
         public double bloodParticleMultiplier = 1f; // multiplier for the quantity of blood particles produced
-        public double bloodParticleDelay = 0.05f;
+        public double bloodParticleDelay = 0.05f; // delay between particle spawns, in seconds
 
         public float bandageMultiplier = 1f; // multiplier for the amount of bleed reduction when using bandages/poultice
 
@@ -36,5 +36,12 @@ namespace BloodyStory.Config
         public float satietyConsumption = 50f; // hunger saturation consumed per point of hp restored
 
         public float timeDilation = 1.0f; // to adjust simulated second speed, for if game speed is changed
+
+        public bool detailedBleedCheck = false; // if true, bleed check key gives precise numbers; if false, it gives vague rating of bleeding
+
+        public float bleedRating_Trivial = 1; // for vague bleed rating: at or below this bleed level is rated "trivial"
+        public float bleedRating_Minor = 3; // as above, for "Minor"
+        public float bleedRating_Moderate = 6; // as above, for "Moderate"
+        public float bleedRating_Severe = 12; // as above, for "Severe"; bleed rates above this will be rated "Extreme"
     }
 }

--- a/BloodyStory/EntityBehaviorBleed.cs
+++ b/BloodyStory/EntityBehaviorBleed.cs
@@ -338,7 +338,7 @@ namespace BloodyStory
             {
                 player.Entity.OnHurt(dmgSource, damage);
                 if (damage > 1f) player.Entity.AnimManager.StartAnimation("hurt");
-                player.Entity.PlayEntitySound("hurt", null, true, 24f);
+                if (dmgSource.Type != EnumDamageType.Heal) player.Entity.PlayEntitySound("hurt", null, true, 24f);
             }
 
             // from Entity.ReceiveDamage

--- a/BloodyStory/EntityBehaviorBleed.cs
+++ b/BloodyStory/EntityBehaviorBleed.cs
@@ -45,6 +45,11 @@ namespace BloodyStory
             get => entity.WatchedAttributes.GetBool("BS_pauseParticles");
             set => entity.WatchedAttributes.SetBool("BS_pauseParticles", value);
         }
+        public double regenRate_clientSync
+        {
+            get => entity.WatchedAttributes.GetDouble("BS_regenRate_clientSync");
+            set => entity.WatchedAttributes.SetDouble("BS_regenRate_clientSync", value);
+        }
 
         private long SitStartTime;
 
@@ -231,6 +236,17 @@ namespace BloodyStory
 
         public double GetRegenRate(bool includeBoost = false)
         {
+            if (entity.Api.Side == EnumAppSide.Client)
+            {
+                if (includeBoost && regenBoost > 0)
+                {
+                    return regenRate_clientSync + modConfig.regenBoostRate;
+                } else
+                {
+                    return regenRate_clientSync;
+                }
+            }
+            
             EntityBehaviorHealth pHealth = entity.GetBehavior<EntityBehaviorHealth>();
             EntityBehaviorHunger pHunger = entity.GetBehavior<EntityBehaviorHunger>();
 
@@ -257,6 +273,8 @@ namespace BloodyStory
             }
             regenRate *= Interpolate(modConfig.minSatietyMultiplier, modConfig.maxSatietyMultiplier, pHunger.Saturation / pHunger.MaxSaturation);
 
+            regenRate_clientSync = regenRate; // TODO: fix this awful hack solution
+            
             if (includeBoost && regenBoost > 0) regenRate += modConfig.regenBoostRate;
 
             return regenRate;

--- a/BloodyStory/changes.txt
+++ b/BloodyStory/changes.txt
@@ -1,9 +1,6 @@
- - removed now-superfluous "unconscious" check :]
- - implemented localisation
- - maybe networked particles? need someone to actually test with other players
- - two new config options to adjust amount of bleed added and to allow some amount of direct damage through
- - removed "bsconfigreload" command, since it seems not to work correctly anyway; you'll just have to reload the config the old fashioned way
- - fix for hunger issues
+- Added a keybind (B by default) that allows you to check your current bleed level or the player you are targeting
+- Added an option for the above, enabled by default, which causes it to give a vague description of the bleed level rather than precise numbers
+- 
 
 TODO: 
 - handbook entry

--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -6,7 +6,7 @@
     "Professor Cupcake"
   ],
   "description": "Changes all combat damage to bleeding",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "dependencies": {
     "game": "*"
   },


### PR DESCRIPTION
- Added a keybind (B by default) that allows you to check your current bleed level or the player you are targeting
- Added an option for the above, enabled by default, which causes it to give a vague description of the bleed level rather than precise numbers
- Bleed chat command now requires admin
- Fixed the hurt sounds when healing